### PR TITLE
Виправити "Типизація" на "Типізація"

### DIFF
--- a/components/DocsWrapper.vue
+++ b/components/DocsWrapper.vue
@@ -40,7 +40,7 @@ addRouteMiddleware(() => {
             Типи даних
           </NuxtLink>
           <NuxtLink href="/docs/types" class="docs-sidebar-menu-item" active-class="active">
-            Типизація
+            Типізація
           </NuxtLink>
           <NuxtLink href="/docs/conditional" class="docs-sidebar-menu-item" active-class="active">
             Умовні оператори


### PR DESCRIPTION
На даний момент на сайті, в розділі документації, в навігаціонній панелі, використовується термін "Типизація", який я пропоную замінити на "Типізація"
Правопис у Вікіпедії: https://uk.wikipedia.org/wiki/Типізація.
Застосування терміну у програмуванні: http://ruslan.rv.ua/python-essential/types_and_data_structures/typing.html.
Словник української мови: http://sum.in.ua/s/typizacija.

"Типизация" - термін на російській, https://ru.wiktionary.org/wiki/типизация.